### PR TITLE
丰富管理员医生管理后端查询功能，解决管理员病人管理前端没办法新增、修改状态没有反响问题，解决管理员医生管理前端状态显示错误、没有查询问题，…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,6 +58,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1535,6 +1536,7 @@
       "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -1591,6 +1593,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -2150,6 +2153,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2304,6 +2308,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2677,6 +2682,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2737,6 +2743,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2784,6 +2791,7 @@
       "integrity": "sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "globals": "^13.24.0",
@@ -3571,13 +3579,15 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-unified": {
       "version": "1.0.3",
@@ -4219,6 +4229,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4284,6 +4295,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4370,6 +4382,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4436,6 +4449,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",

--- a/frontend/src/api/admin-departments.ts
+++ b/frontend/src/api/admin-departments.ts
@@ -1,0 +1,69 @@
+import http from './http';
+
+export interface Department {
+  id?: number;
+  departmentName: string;
+  diseases?: Disease[];
+}
+
+export interface Disease {
+  id?: number;
+  name: string;
+  code?: string;
+  description?: string;
+  departmentId?: number;
+}
+
+export async function fetchDepartments() {
+  const { data } = await http.get<Department[]>('/admin/departments');
+  return data;
+}
+
+export async function fetchDepartment(id: number) {
+  const { data } = await http.get<Department>(`/admin/departments/${id}`);
+  return data;
+}
+
+export async function createDepartment(payload: Department) {
+  const { data } = await http.post<Department>('/admin/departments', payload);
+  return data;
+}
+
+export async function updateDepartment(id: number, payload: Partial<Department>) {
+  const { data } = await http.put<Department>(`/admin/departments/${id}`, payload);
+  return data;
+}
+
+export async function deleteDepartment(id: number) {
+  await http.delete(`/admin/departments/${id}`);
+}
+
+// Diseases under department
+export async function fetchDiseases() {
+  const { data } = await http.get<Disease[]>('/admin/diseases');
+  return data;
+}
+
+export async function fetchDiseaseByDepartment(departmentId: number) {
+  const { data } = await http.get<Disease[]>(`/admin/diseases/department/${departmentId}`);
+  return data;
+}
+
+export async function fetchDisease(id: number) {
+  const { data } = await http.get<Disease>(`/admin/diseases/${id}`);
+  return data;
+}
+
+export async function createDisease(payload: Disease) {
+  const { data } = await http.post<Disease>('/admin/diseases', payload);
+  return data;
+}
+
+export async function updateDisease(id: number, payload: Partial<Disease>) {
+  const { data } = await http.put<Disease>(`/admin/diseases/${id}`, payload);
+  return data;
+}
+
+export async function deleteDisease(id: number) {
+  await http.delete(`/admin/diseases/${id}`);
+}

--- a/frontend/src/api/admin-doctors.ts
+++ b/frontend/src/api/admin-doctors.ts
@@ -12,7 +12,9 @@ export interface Doctor {
   departmentId: number;
   departmentName?: string;
   diseaseIds?: number[];
+  // 后端序列化中可能为 `active` 或 `isActive`，都接收
   isActive?: boolean;
+  active?: boolean;
 }
 
 export interface Department {
@@ -28,8 +30,35 @@ export interface Disease {
   departmentId: number;
 }
 
+export interface PageResult<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  number: number; // current page (0-based)
+  size: number;
+}
+
+export interface DoctorSearchParams {
+  id?: number;
+  doctorId?: string;
+  name?: string;
+  gender?: string;
+  title?: string;
+  departmentId?: number;
+  deleted?: boolean;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
 export async function fetchDoctors() {
   const { data } = await http.get<Doctor[]>('/admin/doctors');
+  return data;
+}
+
+// 新：支持分页和查询参数
+export async function searchDoctors(params: DoctorSearchParams) {
+  const { data } = await http.get<PageResult<Doctor>>('/admin/doctors', { params });
   return data;
 }
 

--- a/frontend/src/api/admin-patients.ts
+++ b/frontend/src/api/admin-patients.ts
@@ -56,3 +56,8 @@ export async function updatePatient(id: number, payload: Partial<Patient>) {
 export async function deletePatient(id: number) {
   await http.delete(`/admin/patients/${id}`);
 }
+
+export async function fetchPatient(id: number) {
+  const { data } = await http.get<Patient>(`/admin/patients/${id}`);
+  return data;
+}

--- a/frontend/src/api/admin-schedule.ts
+++ b/frontend/src/api/admin-schedule.ts
@@ -1,0 +1,67 @@
+import http from './http';
+
+export interface ScheduleDTO {
+  id?: number;
+  doctorProfileId: number;
+  departmentId: number;
+  weekday: number; // 1-5
+  timeslot: string; // AM1..PM4
+  maxPatientsPerSlot?: number;
+}
+
+export interface DoctorProfile {
+  id: number;
+  name?: string;
+  doctorId?: string;
+}
+
+export interface Department {
+  id: number;
+  departmentName?: string;
+}
+
+export interface DoctorDepartmentSchedule {
+  id: number;
+  doctorProfile: DoctorProfile;
+  department: Department;
+  weekday: number;
+  timeslot: string;
+  maxPatientsPerSlot: number;
+}
+
+export interface ResultDTO<T> {
+  code: number;
+  msg?: string;
+  data?: T;
+}
+
+export async function fetchSchedulesByDepartment(deptId: number) {
+  const { data } = await http.get<ResultDTO<DoctorDepartmentSchedule[]>>(`/admin/schedule/department/${deptId}`);
+  return data;
+}
+
+export async function addSchedule(payload: ScheduleDTO) {
+  const { data } = await http.post<ResultDTO<DoctorDepartmentSchedule>>('/admin/schedule', payload);
+  return data;
+}
+
+export async function updateSchedule(payload: ScheduleDTO) {
+  const { data } = await http.put<ResultDTO<DoctorDepartmentSchedule>>('/admin/schedule', payload);
+  return data;
+}
+
+export async function deleteSchedule(scheduleId: number) {
+  const { data } = await http.delete<ResultDTO<void>>(`/admin/schedule/${scheduleId}`);
+  return data;
+}
+
+export async function batchDeleteScheduleByDept(deptId: number) {
+  const { data } = await http.delete<ResultDTO<void>>(`/admin/schedule/batch/department/${deptId}`);
+  return data;
+}
+
+// fetch doctors for a department (public schedule API)
+export async function fetchDoctorsByDepartment(deptId: number) {
+  const { data } = await http.get<DoctorProfile[]>(`/schedule/department/${deptId}/doctors`);
+  return data;
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -27,6 +27,21 @@ const routes: RouteRecordRaw[] = [
         name: 'admin-doctors',
         component: () => import('@/views/admin/DoctorManagementView.vue'),
       },
+      {
+        path: 'departments',
+        name: 'admin-departments',
+        component: () => import('@/views/admin/DepartmentManagementView.vue'),
+      },
+      {
+        path: 'department-diseases',
+        name: 'admin-department-diseases',
+        component: () => import('@/views/admin/DepartmentDiseaseManagementView.vue'),
+      },
+      {
+        path: 'schedules',
+        name: 'admin-schedules',
+        component: () => import('@/views/admin/ScheduleManagementView.vue'),
+      },
     ],
   },
   {

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,52 +1,54 @@
 <template>
   <div class="login-page">
-    <div class="intro">
-      <p class="eyebrow">Registration System</p>
-      <h1>统一登录</h1>
-      <p class="sub">
-        这是 Vue + Element Plus 的前端框架，现阶段以演示为主。
-        示例账号可直接跳转到对应角色欢迎页，后续可无缝对接后端登录接口。
-      </p>
-    </div>
+    <div class="login-inner">
+      <div class="intro">
+        <p class="eyebrow">Registration System</p>
+        <h1>统一登录</h1>
+        <p class="sub">
+          这是 Vue + Element Plus 的前端框架，现阶段以演示为主。
+          示例账号可直接跳转到对应角色欢迎页，后续可无缝对接后端登录接口。
+        </p>
+      </div>
 
-    <el-card class="login-card" shadow="hover">
-      <h3 class="title">账号登录</h3>
-      <el-form :model="form" label-position="top" @submit.prevent="onSubmit">
-        <el-form-item label="用户名">
-          <el-input v-model="form.username" placeholder="例如：admin" autocomplete="username" />
-        </el-form-item>
-        <el-form-item label="密码">
-          <el-input
-            v-model="form.password"
-            type="password"
-            placeholder="请输入密码"
-            show-password
-            autocomplete="current-password"
+      <el-card class="login-card" shadow="hover">
+        <h3 class="title">账号登录</h3>
+        <el-form :model="form" label-position="top" @submit.prevent="onSubmit">
+          <el-form-item label="用户名">
+            <el-input v-model="form.username" placeholder="例如：admin" autocomplete="username" />
+          </el-form-item>
+          <el-form-item label="密码">
+            <el-input
+              v-model="form.password"
+              type="password"
+              placeholder="请输入密码"
+              show-password
+              autocomplete="current-password"
+            />
+          </el-form-item>
+          <el-form-item label="身份">
+            <el-radio-group v-model="form.role">
+              <el-radio-button label="PATIENT">病人</el-radio-button>
+              <el-radio-button label="DOCTOR">医生</el-radio-button>
+              <el-radio-button label="ADMIN">管理员</el-radio-button>
+            </el-radio-group>
+          </el-form-item>
+
+          <el-alert
+            v-if="loginError"
+            type="error"
+            :closable="false"
+            show-icon
+            class="mb-12"
+            :title="loginError"
           />
-        </el-form-item>
-        <el-form-item label="身份">
-          <el-radio-group v-model="form.role">
-            <el-radio-button label="PATIENT">病人</el-radio-button>
-            <el-radio-button label="DOCTOR">医生</el-radio-button>
-            <el-radio-button label="ADMIN">管理员</el-radio-button>
-          </el-radio-group>
-        </el-form-item>
 
-        <el-alert
-          v-if="loginError"
-          type="error"
-          :closable="false"
-          show-icon
-          class="mb-12"
-          :title="loginError"
-        />
-
-        <div class="actions">
-          <el-button type="primary" :loading="loading" class="submit" @click="onSubmit">登录</el-button>
-          <el-button class="submit" plain @click="goRegister">患者注册</el-button>
-        </div>
-      </el-form>
-    </el-card>
+          <div class="actions">
+            <el-button type="primary" :loading="loading" class="submit" @click="onSubmit">登录</el-button>
+            <el-button class="submit" plain @click="goRegister">患者注册</el-button>
+          </div>
+        </el-form>
+      </el-card>
+    </div>
   </div>
 </template>
 
@@ -118,16 +120,24 @@ function goRegister() {
 <style scoped>
 .login-page {
   min-height: 100vh;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 20px;
+  display: flex;
   align-items: center;
-  padding: 48px 32px;
+  justify-content: center;
+  padding: 48px 20px;
   background: radial-gradient(circle at 20% 20%, #f0f6ff, #ffffff 45%), #f5f7fb;
 }
 
+.login-inner {
+  width: 100%;
+  max-width: 1040px; /* constrain overall content */
+  display: grid;
+  grid-template-columns: 1fr 440px; /* left intro and right card fixed width */
+  gap: 32px;
+  align-items: center;
+}
+
 .intro {
-  max-width: 460px;
+  max-width: 560px;
 }
 
 .eyebrow {
@@ -135,39 +145,57 @@ function goRegister() {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: #409eff;
-  margin: 0;
+  margin: 0 0 8px 0;
 }
 
 h1 {
-  margin: 10px 0 6px;
-  font-size: 28px;
+  margin: 6px 0 10px;
+  font-size: 32px;
+  line-height: 1.1;
 }
 
 .sub {
   color: #606266;
   margin: 0 0 12px;
+  font-size: 14px;
 }
 
 .login-card {
-  max-width: 420px;
-  margin-left: auto;
+  width: 100%;
+  max-width: 440px;
+  box-sizing: border-box;
 }
 
 .title {
   margin: 0 0 12px;
+  font-weight: 600;
+}
+
+/* Actions: inline on wide screens, stacked on small screens */
+.actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
 }
 
 .submit {
-  width: 100%;
+  flex: 1 1 0;
 }
 
-.actions {
-  display: flex;
-  gap: 10px;
-  flex-direction: column;
+/* make buttons side-by-side on wider viewports */
+@media (min-width: 720px) {
+  .actions { flex-direction: row; }
+  .submit { width: auto; }
 }
 
-.mb-12 {
-  margin-bottom: 12px;
+/* for small screens stack vertically */
+@media (max-width: 719px) {
+  .login-inner { grid-template-columns: 1fr; }
+  .intro { order: 1; }
+  .login-card { order: 2; }
+  .actions { flex-direction: column; }
+  .submit { width: 100%; }
 }
+
+.mb-12 { margin-bottom: 12px; }
 </style>

--- a/frontend/src/views/admin/AdminHomeView.vue
+++ b/frontend/src/views/admin/AdminHomeView.vue
@@ -27,18 +27,49 @@
         <el-card shadow="hover">
           <div class="card-title">病人管理</div>
           <p class="card-sub">查询 / 新增 / 编辑 / 停用患者账号</p>
+          <div class="card-actions">
+            <el-button type="primary" size="small" @click="$router.push('/admin/patients')">前往</el-button>
+          </div>
         </el-card>
       </el-col>
+
       <el-col :xs="24" :sm="12" :md="8">
         <el-card shadow="hover">
           <div class="card-title">医生管理</div>
           <p class="card-sub">分配科室、疾病，可随时软删除或恢复</p>
+          <div class="card-actions">
+            <el-button type="primary" size="small" @click="$router.push('/admin/doctors')">前往</el-button>
+          </div>
         </el-card>
       </el-col>
+
+      <el-col :xs="24" :sm="12" :md="8">
+        <el-card shadow="hover">
+          <div class="card-title">科室管理</div>
+          <p class="card-sub">维护科室信息，创建/编辑科室以及关联疾病</p>
+          <div class="card-actions">
+            <el-button type="primary" size="small" @click="$router.push('/admin/departments')">前往</el-button>
+          </div>
+        </el-card>
+      </el-col>
+
+      <el-col :xs="24" :sm="12" :md="8">
+        <el-card shadow="hover">
+          <div class="card-title">科室相关疾病</div>
+          <p class="card-sub">查看/新增/编辑科室下的疾病项，支持按科室筛选</p>
+          <div class="card-actions">
+            <el-button type="primary" size="small" @click="$router.push('/admin/department-diseases')">前往</el-button>
+          </div>
+        </el-card>
+      </el-col>
+
       <el-col :xs="24" :sm="12" :md="8">
         <el-card shadow="hover">
           <div class="card-title">排班管理</div>
-          <p class="card-sub">按 weekday + timeslot 管理一周班表</p>
+          <p class="card-sub">按星期与时间段管理医生排班，支持新增/编辑/删除/清空</p>
+          <div class="card-actions">
+            <el-button type="primary" size="small" @click="$router.push('/admin/schedules')">前往</el-button>
+          </div>
         </el-card>
       </el-col>
     </el-row>
@@ -116,5 +147,9 @@
 .card-sub {
   margin: 0;
   color: #666;
+}
+
+.card-actions {
+  margin-top: 12px;
 }
 </style>

--- a/frontend/src/views/admin/AdminLayout.vue
+++ b/frontend/src/views/admin/AdminLayout.vue
@@ -6,7 +6,9 @@
         <el-menu-item index="/admin/home">首页</el-menu-item>
         <el-menu-item index="/admin/patients">病人管理</el-menu-item>
         <el-menu-item index="/admin/doctors">医生管理</el-menu-item>
-        <el-menu-item index="/admin/schedule" disabled>排班管理（TODO）</el-menu-item>
+        <el-menu-item index="/admin/departments">科室管理</el-menu-item>
+        <el-menu-item index="/admin/department-diseases">科室疾病</el-menu-item>
+        <el-menu-item index="/admin/schedules">排班管理</el-menu-item>
       </el-menu>
     </el-aside>
     <el-container>

--- a/frontend/src/views/admin/DepartmentDiseaseManagementView.vue
+++ b/frontend/src/views/admin/DepartmentDiseaseManagementView.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="page">
+    <div class="header">
+      <div>
+        <h2>科室疾病管理</h2>
+        <p class="sub">选择科室后，可新增、编辑该科室下的疾病。</p>
+      </div>
+      <div>
+        <el-select v-model="selectedDeptId" placeholder="请选择科室" style="width:260px" filterable @change="onDeptChange">
+          <el-option v-for="d in departments" :key="d.id" :label="d.departmentName" :value="d.id" />
+        </el-select>
+        <el-button type="primary" plain @click="resetFilter" style="margin-left:8px">显示全部疾病</el-button>
+        <el-button type="primary" @click="openCreate" :disabled="!selectedDeptId" style="margin-left:8px">新增疾病</el-button>
+      </div>
+    </div>
+
+    <el-table :data="diseases" v-loading="loading" border style="background:#fff;" size="small">
+      <el-table-column prop="id" label="ID" width="80" />
+      <el-table-column prop="name" label="疾病名称" />
+      <el-table-column prop="code" label="编码" width="140" />
+      <el-table-column prop="description" label="描述" />
+      <el-table-column prop="departmentName" label="科室" width="180" />
+      <el-table-column label="操作" width="220" fixed="right">
+        <template #default="{ row }">
+          <el-button size="small" @click="openEdit(row)">编辑</el-button>
+          <el-popconfirm title="确认删除该疾病？" @confirm="onDelete(row)">
+            <template #reference>
+              <el-button size="small" type="danger">删除</el-button>
+            </template>
+          </el-popconfirm>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialogVisible" :title="dialogTitle" width="640px">
+      <el-form :model="form" ref="formRef" label-width="120px">
+        <el-form-item label="疾病名称" prop="name" :rules="[{ required: true, message: '请输入疾病名称', trigger: 'blur' }]">
+          <el-input v-model="form.name" />
+        </el-form-item>
+        <el-form-item label="编码" prop="code">
+          <el-input v-model="form.code" />
+        </el-form-item>
+        <el-form-item label="描述" prop="description">
+          <el-input type="textarea" v-model="form.description" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="onSubmit">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, onMounted } from 'vue';
+import { ElMessage } from 'element-plus';
+import {
+  fetchDepartments,
+  fetchDiseaseByDepartment,
+  fetchDiseases,
+  createDisease,
+  updateDisease,
+  deleteDisease,
+  type Department,
+  type Disease,
+} from '@/api/admin-departments';
+
+const loading = ref(false);
+const saving = ref(false);
+const departments = ref<Department[]>([]);
+const diseases = ref<Disease[]>([]);
+
+const selectedDeptId = ref<number | null>(null);
+
+const dialogVisible = ref(false);
+const formRef = ref();
+const form = reactive<Disease>({ name: '', code: '', description: '', departmentId: undefined });
+
+const isEdit = () => !!(form as any).id;
+const dialogTitle = () => (isEdit() ? '编辑疾病' : '新增疾病');
+
+async function load() {
+  loading.value = true;
+  try {
+    departments.value = await fetchDepartments();
+    diseases.value = await fetchDiseases(); // 默认加载全部疾病
+  } catch (err: any) {
+    ElMessage.error(err?.response?.data?.message || '加载科室失败');
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function onDeptChange() {
+  if (!selectedDeptId.value) {
+    diseases.value = await fetchDiseases();
+    return;
+  }
+  loading.value = true;
+  try {
+    diseases.value = await fetchDiseaseByDepartment(selectedDeptId.value);
+  } catch (err: any) {
+    ElMessage.error(err?.response?.data?.message || '加载疾病失败');
+  } finally {
+    loading.value = false;
+  }
+}
+
+function resetFilter() {
+  selectedDeptId.value = null;
+  onDeptChange();
+}
+
+function openCreate() {
+  Object.assign(form, { id: undefined, name: '', code: '', description: '', departmentId: selectedDeptId.value } as any);
+  dialogVisible.value = true;
+}
+
+function openEdit(row: Disease) {
+  Object.assign(form, row as any);
+  dialogVisible.value = true;
+}
+
+async function onSubmit() {
+  if (!formRef.value) return;
+  try {
+    if (!form.name || !form.name.trim()) {
+      ElMessage.error('请输入疾病名称');
+      return;
+    }
+    saving.value = true;
+    if (isEdit()) {
+      await updateDisease((form as any).id, form as any);
+      ElMessage.success('更新成功');
+    } else {
+      // ensure departmentId set
+      await createDisease({ ...form as any, departmentId: selectedDeptId.value } as any);
+      ElMessage.success('创建成功');
+    }
+    dialogVisible.value = false;
+    await onDeptChange();
+  } catch (err: any) {
+    ElMessage.error(err?.response?.data?.message || '操作失败');
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function onDelete(row: Disease) {
+  if (!(row as any).id) return;
+  try {
+    await deleteDisease((row as any).id);
+    ElMessage.success('已删除');
+    await onDeptChange();
+  } catch (err: any) {
+    ElMessage.error(err?.response?.data?.message || '删除失败');
+  }
+}
+
+onMounted(load);
+</script>
+
+<style scoped>
+.page { padding: 12px }
+.header { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px }
+.sub { margin:0; color:#606266 }
+</style>

--- a/frontend/src/views/admin/DepartmentManagementView.vue
+++ b/frontend/src/views/admin/DepartmentManagementView.vue
@@ -1,0 +1,186 @@
+<template>
+  <div class="page">
+    <div class="header">
+      <div>
+        <h2>科室管理</h2>
+        <p class="sub">新增、编辑或删除科室，删除前会检查是否有关联疾病。</p>
+      </div>
+      <el-button type="primary" @click="openCreate">新增科室</el-button>
+    </div>
+
+    <el-table :data="departments" border v-loading="loading">
+      <el-table-column prop="id" label="ID" width="80" />
+      <el-table-column prop="departmentName" label="科室名称" />
+      <el-table-column label="操作" width="220" fixed="right">
+        <template #default="{ row }">
+          <el-button size="small" @click="openEdit(row)">编辑</el-button>
+          <el-popconfirm title="确认删除该科室？" @confirm="onDelete(row)">
+            <template #reference>
+              <el-button size="small" type="danger">删除</el-button>
+            </template>
+          </el-popconfirm>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialogVisible" :title="dialogTitle" width="720px">
+      <el-form :model="form" ref="formRef" label-width="100px">
+        <el-form-item label="科室名称" prop="departmentName" :rules="[{ required: true, message: '请输入科室名称', trigger: 'blur' }]">
+          <el-input v-model="form.departmentName" />
+        </el-form-item>
+
+        <el-divider>科室相关疾病（可选）</el-divider>
+
+        <el-table :data="form.diseases" style="width:100%" size="small" border>
+          <el-table-column prop="name" label="名称">
+            <template #default="{ row }">
+              <el-input v-model="row.name" placeholder="疾病名称" />
+            </template>
+          </el-table-column>
+          <el-table-column prop="code" label="编码" width="180">
+            <template #default="{ row }">
+              <el-input v-model="row.code" placeholder="编码（可选）" />
+            </template>
+          </el-table-column>
+          <el-table-column prop="description" label="描述">
+            <template #default="{ row }">
+              <el-input v-model="row.description" placeholder="描述（可选）" />
+            </template>
+          </el-table-column>
+          <el-table-column label="操作" width="100">
+            <template #default="{ row }">
+              <el-button type="danger" size="small" @click="removeDiseaseByRow(row)">删除</el-button>
+            </template>
+          </el-table-column>
+        </el-table>
+
+        <div style="margin-top:12px;">
+          <el-button type="primary" @click="addDisease">新增一行疾病</el-button>
+        </div>
+
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="onSubmit">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed, onMounted } from 'vue';
+import { ElMessage } from 'element-plus';
+import {
+  fetchDepartments,
+  createDepartment,
+  updateDepartment,
+  deleteDepartment,
+  fetchDepartment,
+  type Department,
+} from '@/api/admin-departments';
+
+const loading = ref(false);
+const saving = ref(false);
+const departments = ref<Department[]>([]);
+
+const dialogVisible = ref(false);
+const formRef = ref();
+const form = reactive<Department>({ departmentName: '', diseases: [] as any[] });
+
+const isEdit = computed(() => Boolean((form as any).id));
+const dialogTitle = computed(() => (isEdit.value ? '编辑科室' : '新增科室'));
+
+async function load() {
+  loading.value = true;
+  try {
+    departments.value = await fetchDepartments();
+  } catch (err: any) {
+    ElMessage.error(err?.response?.data?.message || '加载失败');
+  } finally {
+    loading.value = false;
+  }
+}
+
+function openCreate() {
+  Object.assign(form, { id: undefined, departmentName: '', diseases: [] } as any);
+  dialogVisible.value = true;
+}
+
+async function openEdit(row: Department) {
+  // fetch full details including diseases
+  try {
+    loading.value = true;
+    const full = await fetchDepartment((row as any).id);
+    Object.assign(form, full as any);
+  } catch (err: any) {
+    ElMessage.error(err?.response?.data?.message || '加载科室失败');
+    return;
+  } finally {
+    loading.value = false;
+  }
+  dialogVisible.value = true;
+}
+
+function addDisease() {
+  (form.diseases = form.diseases || []).push({ name: '', code: '', description: '' });
+}
+
+function removeDisease(idx: number) {
+  form.diseases?.splice(idx, 1);
+}
+
+function removeDiseaseByRow(row: any) {
+  const list = form.diseases || [];
+  const idx = list.indexOf(row);
+  if (idx !== -1) removeDisease(idx);
+}
+
+async function onSubmit() {
+  if (!formRef.value) return;
+  try {
+    // simple validation
+    if (!form.departmentName || !form.departmentName.trim()) {
+      ElMessage.error('请输入科室名称');
+      return;
+    }
+    saving.value = true;
+    const payload = {
+      departmentName: form.departmentName,
+      diseases: form.diseases?.filter((d: any) => d.name && d.name.trim()).map((d: any) => ({ name: d.name, code: d.code, description: d.description })) || [],
+    } as any;
+
+    if (isEdit.value && (form as any).id) {
+      await updateDepartment((form as any).id, payload);
+      ElMessage.success('更新成功');
+    } else {
+      await createDepartment(payload);
+      ElMessage.success('创建成功');
+    }
+    dialogVisible.value = false;
+    await load();
+  } catch (err: any) {
+    ElMessage.error(err?.response?.data?.message || '操作失败');
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function onDelete(row: Department) {
+  if (!(row as any).id) return;
+  try {
+    await deleteDepartment((row as any).id);
+    ElMessage.success('已删除');
+    await load();
+  } catch (err: any) {
+    ElMessage.error(err?.response?.data?.message || '删除失败：可能存在关联疾病');
+  }
+}
+
+onMounted(load);
+</script>
+
+<style scoped>
+.page { padding: 12px; }
+.header { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px }
+.sub { margin:0; color:#606266 }
+</style>

--- a/frontend/src/views/admin/ScheduleManagementView.vue
+++ b/frontend/src/views/admin/ScheduleManagementView.vue
@@ -1,0 +1,279 @@
+<template>
+  <div class="schedule-manager">
+    <div class="controls">
+      <el-select v-model="selectedDeptId" placeholder="请选择科室" style="min-width:260px" @change="onDeptChange" clearable>
+        <el-option v-for="d in departments" :key="d.id" :label="d.departmentName" :value="d.id" />
+      </el-select>
+      <el-button type="primary" :disabled="!selectedDeptId" @click="openCreate">新增排班</el-button>
+      <el-button type="danger" :disabled="!selectedDeptId || loading" @click="confirmBatchDelete">清空该科室排班</el-button>
+    </div>
+
+    <el-card class="table-card" v-loading="loading">
+      <el-table :data="schedules" stripe style="width:100%">
+        <el-table-column prop="id" label="ID" width="80" />
+        <el-table-column label="医生" width="220">
+          <template #default="{ row }">
+            {{ row.doctorProfile?.name || row.doctorProfile?.doctorId || '—' }}
+          </template>
+        </el-table-column>
+        <el-table-column label="星期" width="100">
+          <template #default="{ row }">{{ weekdayLabel(row.weekday) }}</template>
+        </el-table-column>
+        <el-table-column label="时间段" width="140">
+          <template #default="{ row }">{{ timeslotLabel(row.timeslot) }}</template>
+        </el-table-column>
+        <el-table-column label="每时段最大人数" width="160">
+          <template #default="{ row }">{{ row.maxPatientsPerSlot ?? '-' }}</template>
+        </el-table-column>
+        <el-table-column label="操作" width="200" fixed="right">
+          <template #default="{ row }">
+            <el-button size="small" type="primary" @click="openEdit(row)">编辑</el-button>
+            <el-popconfirm title="确认删除该排班？" confirm-button-text="删除" @confirm="() => onDelete(row)">
+              <template #reference>
+                <el-button size="small" type="danger">删除</el-button>
+              </template>
+            </el-popconfirm>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <div v-if="!schedules.length && selectedDeptId && !loading" class="empty-note">该科室暂无排班</div>
+    </el-card>
+
+    <el-dialog :title="dialogTitleLocal" :visible.sync="dialogVisible" width="520px" :destroy-on-close="true">
+      <el-form :model="form" :rules="rules" ref="formRef" label-width="140px">
+        <el-form-item label="科室" prop="departmentId">
+          <el-select v-model.number="form.departmentId" disabled>
+            <el-option v-for="d in departments" :key="d.id" :label="d.departmentName" :value="d.id" />
+          </el-select>
+        </el-form-item>
+
+        <el-form-item label="医生" prop="doctorProfileId">
+          <el-select v-model.number="form.doctorProfileId" placeholder="请选择医生">
+            <el-option v-for="doc in doctors" :key="doc.id" :label="doc.name + (doc.doctorId ? ' ('+doc.doctorId+')':'')" :value="doc.id" />
+          </el-select>
+        </el-form-item>
+
+        <el-form-item label="星期（1-5）" prop="weekday">
+          <el-select v-model.number="form.weekday" placeholder="选择星期">
+            <el-option v-for="n in [1,2,3,4,5]" :key="n" :label="weekdayLabel(n)" :value="n" />
+          </el-select>
+        </el-form-item>
+
+        <el-form-item label="时间段" prop="timeslot">
+          <el-select v-model="form.timeslot" placeholder="选择时间段">
+            <el-option v-for="ts in TIME_SLOTS" :key="ts" :label="timeslotLabel(ts)" :value="ts" />
+          </el-select>
+        </el-form-item>
+
+        <el-form-item label="每时段最大人数" prop="maxPatientsPerSlot">
+          <el-input-number v-model.number="form.maxPatientsPerSlot" :min="1" :controls="true" />
+        </el-form-item>
+      </el-form>
+
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="submitForm">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed } from 'vue';
+import { ElMessage, ElMessageBox } from 'element-plus';
+import { fetchDepartments } from '@/api/admin-departments';
+import {
+  fetchSchedulesByDepartment,
+  addSchedule,
+  updateSchedule,
+  deleteSchedule,
+  batchDeleteScheduleByDept,
+  fetchDoctorsByDepartment,
+  type ScheduleDTO,
+  type DoctorDepartmentSchedule,
+  type DoctorProfile,
+} from '@/api/admin-schedule';
+
+const loading = ref(false);
+const saving = ref(false);
+const departments = ref<any[]>([]);
+const doctors = ref<DoctorProfile[]>([]);
+const schedules = ref<DoctorDepartmentSchedule[]>([]);
+
+const selectedDeptId = ref<number | null>(null);
+
+const dialogVisible = ref(false);
+const formRef = ref();
+const form = reactive<Partial<ScheduleDTO>>({ departmentId: undefined, doctorProfileId: undefined, weekday: 1, timeslot: 'AM1', maxPatientsPerSlot: 2 });
+
+const TIME_SLOTS = ['AM1','AM2','AM3','AM4','PM1','PM2','PM3','PM4'];
+function timeslotLabel(ts: string) {
+  const map: Record<string,string> = { AM1:'上午1',AM2:'上午2',AM3:'上午3',AM4:'上午4',PM1:'下午1',PM2:'下午2',PM3:'下午3',PM4:'下午4' };
+  return map[ts] || ts;
+}
+function weekdayLabel(n: number) { const map = ['周一','周二','周三','周四','周五']; return map[(n||1)-1] || String(n); }
+
+const dialogTitleLocal = computed(() => form && (form as any).id ? '编辑排班' : '新增排班');
+
+const rules = {
+  doctorProfileId: [{ required: true, message: '请选择医生', trigger: 'change' }],
+  weekday: [{ required: true, message: '请选择星期', trigger: 'change' }],
+  timeslot: [{ required: true, message: '请选择时间段', trigger: 'change' }],
+  maxPatientsPerSlot: [{ type: 'number', min: 1, message: '人数必须 >= 1', trigger: 'change' }],
+};
+
+function getErrorMessage(err: any) {
+  if (!err) return '操作失败';
+  if (err.response && err.response.data) return err.response.data.msg || err.response.data.message || JSON.stringify(err.response.data);
+  return err.message || String(err);
+}
+
+async function loadDepartments() {
+  loading.value = true;
+  try {
+    departments.value = await fetchDepartments();
+  } catch (err: any) {
+    ElMessage.error(getErrorMessage(err));
+  } finally { loading.value = false; }
+}
+
+async function onDeptChange() {
+  schedules.value = [];
+  doctors.value = [];
+  if (!selectedDeptId.value) return;
+  loading.value = true;
+  try {
+    const res = await fetchSchedulesByDepartment(selectedDeptId.value);
+    if (res && res.code === 200) {
+      // normalize schedule fields (backend may return different key styles)
+      schedules.value = (res.data || []).map((s: any) => {
+        const sch: any = { ...s };
+        sch.maxPatientsPerSlot = s.maxPatientsPerSlot ?? s.max_patients_per_slot ?? s.maxPatients ?? 2;
+        // unify timeslot
+        if (s.timeslot && typeof s.timeslot === 'string') sch.timeslot = s.timeslot;
+        else if (s.timeslot && s.timeslot.name) sch.timeslot = s.timeslot.name;
+        else sch.timeslot = String(s.timeslot || '');
+        // unify doctorProfile field
+        sch.doctorProfile = s.doctorProfile || s.doctor || s.doctor_profile || null;
+        // unify department
+        sch.department = s.department || s.dept || s.department_name ? { id: s.department?.id ?? s.dept?.id, departmentName: s.department?.departmentName ?? s.department_name } : s.department;
+        return sch;
+      });
+    } else throw new Error(res?.msg || '加载排班失败');
+
+    // fetch doctors for department (public schedule API)
+    try {
+      const docs = await fetchDoctorsByDepartment(selectedDeptId.value);
+      // normalize doctor fields
+      doctors.value = (docs || []).map((d: any) => ({ id: d.id ?? d.doctorProfileId ?? d.userId, name: d.name ?? d.fullName ?? d.username, doctorId: d.doctorId ?? d.employeeNumber }));
+    } catch (e) {
+      doctors.value = [];
+    }
+  } catch (err: any) {
+    ElMessage.error(getErrorMessage(err));
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function openCreate() {
+  if (!selectedDeptId.value) return ElMessage.warning('请先选择科室');
+  // ensure doctors loaded
+  if (!doctors.value || doctors.value.length === 0) {
+    try {
+      const docs = await fetchDoctorsByDepartment(selectedDeptId.value);
+      doctors.value = (docs || []).map((d: any) => ({ id: d.id ?? d.doctorProfileId ?? d.userId, name: d.name ?? d.fullName ?? d.username, doctorId: d.doctorId ?? d.employeeNumber }));
+    } catch (e) {
+      doctors.value = [];
+    }
+  }
+  Object.assign(form, { id: undefined, departmentId: selectedDeptId.value, doctorProfileId: undefined, weekday: 1, timeslot: 'AM1', maxPatientsPerSlot: 2 });
+  dialogVisible.value = true;
+}
+
+async function openEdit(row: DoctorDepartmentSchedule) {
+  // set selectedDeptId so UI consistent
+  if (row.department?.id) selectedDeptId.value = row.department.id;
+  // ensure doctors loaded for this dept
+  try {
+    const docs = await fetchDoctorsByDepartment(selectedDeptId.value as number);
+    doctors.value = (docs || []).map((d: any) => ({ id: d.id ?? d.doctorProfileId ?? d.userId, name: d.name ?? d.fullName ?? d.username, doctorId: d.doctorId ?? d.employeeNumber }));
+  } catch (e) {
+    doctors.value = [];
+  }
+  Object.assign(form, { id: row.id, departmentId: row.department?.id, doctorProfileId: row.doctorProfile?.id, weekday: row.weekday, timeslot: row.timeslot, maxPatientsPerSlot: row.maxPatientsPerSlot });
+  dialogVisible.value = true;
+}
+
+async function submitForm() {
+  if (!formRef.value) return;
+  const valid = await formRef.value.validate().catch(() => false);
+  if (!valid) return;
+  saving.value = true;
+  try {
+    const payload: ScheduleDTO = {
+      id: (form as any).id,
+      doctorProfileId: Number(form.doctorProfileId),
+      departmentId: Number(form.departmentId ?? selectedDeptId.value),
+      weekday: Number(form.weekday),
+      timeslot: String(form.timeslot).toUpperCase(),
+      maxPatientsPerSlot: form.maxPatientsPerSlot ? Number(form.maxPatientsPerSlot) : undefined,
+    };
+
+    console.debug('[Schedule] submit payload:', payload);
+    if ((form as any).id) {
+      const res = await updateSchedule(payload);
+      console.debug('[Schedule] update response:', res);
+      if (!res || res.code !== 200) throw new Error(res?.msg || '更新失败');
+      ElMessage.success('更新成功');
+    } else {
+      const res = await addSchedule(payload);
+      console.debug('[Schedule] add response:', res);
+      if (!res || res.code !== 200) throw new Error(res?.msg || '创建失败');
+      ElMessage.success('创建成功');
+    }
+    dialogVisible.value = false;
+    // reset form to default after success
+    Object.assign(form, { id: undefined, departmentId: undefined, doctorProfileId: undefined, weekday: 1, timeslot: 'AM1', maxPatientsPerSlot: 2 });
+    await onDeptChange();
+  } catch (err: any) {
+    console.error('[Schedule] submit error:', err);
+    ElMessage.error(getErrorMessage(err));
+  } finally { saving.value = false; }
+}
+
+async function onDelete(row: DoctorDepartmentSchedule) {
+  try {
+    await ElMessageBox.confirm('确认删除该排班？', '删除确认', { type: 'warning' });
+  } catch { return; }
+  try {
+    const res = await deleteSchedule(row.id);
+    if (!res || res.code !== 200) throw new Error(res?.msg || '删除失败');
+    ElMessage.success('删除成功');
+    await onDeptChange();
+  } catch (err: any) { ElMessage.error(getErrorMessage(err)); }
+}
+
+async function confirmBatchDelete() {
+  try {
+    await ElMessageBox.confirm('确认清空该科室所有排班？此操作不可逆。', '清空确认', { type: 'warning' });
+  } catch { return; }
+  try {
+    const res = await batchDeleteScheduleByDept(selectedDeptId as unknown as number);
+    if (!res || res.code !== 200) throw new Error(res?.msg || '清空失败');
+    ElMessage.success('已清空该科室排班');
+    await onDeptChange();
+  } catch (err: any) { ElMessage.error(getErrorMessage(err)); }
+}
+
+// initial load
+loadDepartments();
+</script>
+
+<style scoped>
+.schedule-manager { padding: 16px; }
+.controls { display:flex; gap:12px; align-items:center; margin-bottom:12px }
+.table-card { padding:12px }
+.empty-note { margin-top:12px; color:#909399 }
+</style>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "registration-system-root",
+  "private": true,
+  "scripts": {
+    "dev": "npm --prefix frontend run dev",
+    "build": "npm --prefix frontend run build",
+    "install-frontend": "npm --prefix frontend install",
+    "lint-frontend": "npm --prefix frontend run lint"
+  }
+}
+

--- a/src/main/java/com/hospital/ouc/registrationsystem/domain/repository/DoctorProfileRepository.java
+++ b/src/main/java/com/hospital/ouc/registrationsystem/domain/repository/DoctorProfileRepository.java
@@ -2,11 +2,12 @@ package com.hospital.ouc.registrationsystem.domain.repository;
 
 import com.hospital.ouc.registrationsystem.domain.entity.DoctorProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface DoctorProfileRepository extends JpaRepository<DoctorProfile, Long> {
+public interface DoctorProfileRepository extends JpaRepository<DoctorProfile, Long>, JpaSpecificationExecutor<DoctorProfile> {
     /**
      * 通过统一用户ID查询医生档案，用于登录后绑定身份。
      */

--- a/src/main/java/com/hospital/ouc/registrationsystem/domain/service/Admin_DoctorService.java
+++ b/src/main/java/com/hospital/ouc/registrationsystem/domain/service/Admin_DoctorService.java
@@ -6,6 +6,11 @@ import com.hospital.ouc.registrationsystem.domain.enums.Role;
 import com.hospital.ouc.registrationsystem.domain.repository.*;
 import com.hospital.ouc.registrationsystem.web.dto.DoctorDTO;
 import com.hospital.ouc.registrationsystem.web.dto.DoctorUpdateDTO;
+import com.hospital.ouc.registrationsystem.web.dto.DoctorSearchCriteria;
+import com.hospital.ouc.registrationsystem.domain.specification.DoctorProfileSpecification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -243,5 +248,14 @@ public class Admin_DoctorService {
         } catch (Exception e) {
             throw new RuntimeException("密码加密失败", e);
         }
+    }
+
+    // 新增：按条件分页查询医生（管理员使用）
+    public Page<DoctorDTO> searchDoctors(DoctorSearchCriteria criteria, Pageable pageable) {
+        // 构建 Specification
+        var spec = DoctorProfileSpecification.build(criteria);
+        var page = doctorProfileRepository.findAll(spec, pageable);
+        List<DoctorDTO> dtoList = page.getContent().stream().map(this::convertToDTO).collect(Collectors.toList());
+        return new PageImpl<>(dtoList, pageable, page.getTotalElements());
     }
 }

--- a/src/main/java/com/hospital/ouc/registrationsystem/domain/service/impl/PatientManagementServiceImpl.java
+++ b/src/main/java/com/hospital/ouc/registrationsystem/domain/service/impl/PatientManagementServiceImpl.java
@@ -143,6 +143,15 @@ public class PatientManagementServiceImpl implements PatientManagementService {
             profile.setGender(patientDTO.getGender());
         }
 
+        // 8. 修改在职/有效状态（传值才处理，未传跳过）
+        if (patientDTO.getIsActive() != null) {
+            profile.setIsActive(patientDTO.getIsActive());
+            if (user != null) {
+                user.setIsActive(patientDTO.getIsActive());
+                appUserRepository.save(user);
+            }
+        }
+
         // 8. 保存修改（仅保存有变更的字段）
         PatientProfile updatedProfile = patientProfileRepository.save(profile);
 

--- a/src/main/java/com/hospital/ouc/registrationsystem/domain/specification/DoctorProfileSpecification.java
+++ b/src/main/java/com/hospital/ouc/registrationsystem/domain/specification/DoctorProfileSpecification.java
@@ -1,0 +1,59 @@
+package com.hospital.ouc.registrationsystem.domain.specification;
+
+import com.hospital.ouc.registrationsystem.domain.entity.Department;
+import com.hospital.ouc.registrationsystem.domain.entity.DoctorProfile;
+import com.hospital.ouc.registrationsystem.web.dto.DoctorSearchCriteria;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DoctorProfileSpecification {
+
+    public static Specification<DoctorProfile> build(DoctorSearchCriteria criteria) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (criteria == null) return cb.and(predicates.toArray(new Predicate[0]));
+
+            if (criteria.getId() != null) {
+                predicates.add(cb.equal(root.get("id"), criteria.getId()));
+            }
+
+            if (StringUtils.hasText(criteria.getDoctorId())) {
+                predicates.add(cb.equal(root.get("doctorId"), criteria.getDoctorId()));
+            }
+
+            if (StringUtils.hasText(criteria.getName())) {
+                predicates.add(cb.like(cb.lower(root.get("name")), "%" + criteria.getName().toLowerCase() + "%"));
+            }
+
+            if (StringUtils.hasText(criteria.getGender())) {
+                // gender is an enum stored as string (male/female)
+                // compare enum as string to avoid type mismatch
+                predicates.add(cb.equal(cb.lower(root.get("gender").as(String.class)), criteria.getGender().toLowerCase()));
+            }
+
+            if (StringUtils.hasText(criteria.getTitle())) {
+                predicates.add(cb.like(cb.lower(root.get("title")), "%" + criteria.getTitle().toLowerCase() + "%"));
+            }
+
+            if (criteria.getDepartmentId() != null) {
+                Join<DoctorProfile, Department> dept = root.join("department", JoinType.LEFT);
+                predicates.add(cb.equal(dept.get("id"), criteria.getDepartmentId()));
+            }
+
+            if (criteria.getDeleted() != null) {
+                // in this project, soft-delete is represented by isActive boolean
+                // deleted == true -> isActive == false; deleted == false -> isActive == true
+                predicates.add(cb.equal(root.get("isActive"), !criteria.getDeleted()));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/com/hospital/ouc/registrationsystem/web/AdminDoctorController.java
+++ b/src/main/java/com/hospital/ouc/registrationsystem/web/AdminDoctorController.java
@@ -3,6 +3,11 @@ package com.hospital.ouc.registrationsystem.web;
 import com.hospital.ouc.registrationsystem.domain.service.Admin_DoctorService;
 import com.hospital.ouc.registrationsystem.web.dto.DoctorDTO;
 import com.hospital.ouc.registrationsystem.web.dto.DoctorUpdateDTO;
+import com.hospital.ouc.registrationsystem.web.dto.DoctorSearchCriteria;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -19,10 +24,35 @@ public class AdminDoctorController {
 
     private final Admin_DoctorService doctorService;
 
-    // 获取所有医生
+    // 获取/查询医生（支持分页与筛选）
     @GetMapping
-    public ResponseEntity<List<DoctorDTO>> getAllDoctors() {
-        return ResponseEntity.ok(doctorService.getAllDoctors());
+    public ResponseEntity<Page<DoctorDTO>> searchDoctors(
+            @RequestParam(required = false) Long id,
+            @RequestParam(required = false) String doctorId,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String gender,
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) Long departmentId,
+            @RequestParam(required = false) Boolean deleted,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "id,desc") String sort
+    ) {
+        DoctorSearchCriteria criteria = new DoctorSearchCriteria();
+        criteria.setId(id);
+        criteria.setDoctorId(doctorId);
+        criteria.setName(name);
+        criteria.setGender(gender);
+        criteria.setTitle(title);
+        criteria.setDepartmentId(departmentId);
+        criteria.setDeleted(deleted);
+
+        // parse sort like "id,desc" or "name,asc"
+        String[] sortParts = sort.split(",");
+        Sort s = Sort.by(Sort.Direction.fromString(sortParts.length > 1 ? sortParts[1] : "desc"), sortParts[0]);
+        Pageable pageable = PageRequest.of(page, size, s);
+
+        return ResponseEntity.ok(doctorService.searchDoctors(criteria, pageable));
     }
 
     // 根据ID获取医生

--- a/src/main/java/com/hospital/ouc/registrationsystem/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/hospital/ouc/registrationsystem/web/GlobalExceptionHandler.java
@@ -18,8 +18,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<Map<String, Object>> handleRuntime(RuntimeException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("error", ex.getMessage());
+        // return as { message: "..." } to match frontend expectations
+        body.put("message", ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 }
-

--- a/src/main/java/com/hospital/ouc/registrationsystem/web/dto/DepartmentDTO.java
+++ b/src/main/java/com/hospital/ouc/registrationsystem/web/dto/DepartmentDTO.java
@@ -3,10 +3,15 @@ package com.hospital.ouc.registrationsystem.web.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class DepartmentDTO {
     private Long id;
 
     @NotBlank(message = "科室名称不能为空")
     private String departmentName;
+
+    // 新增：可携带该科室的疾病列表（新增时可提供，查询时返回）
+    private List<DiseaseDTO> diseases;
 }

--- a/src/main/java/com/hospital/ouc/registrationsystem/web/dto/DoctorSearchCriteria.java
+++ b/src/main/java/com/hospital/ouc/registrationsystem/web/dto/DoctorSearchCriteria.java
@@ -1,0 +1,20 @@
+package com.hospital.ouc.registrationsystem.web.dto;
+
+import lombok.Data;
+
+@Data
+public class DoctorSearchCriteria {
+    private Long id;
+    private String doctorId;
+    private String name;
+    private String gender;
+    private String title;
+    private Long departmentId;
+    /**
+     * 表示是否查询已软删除的记录：
+     *  - null 表示不按软删除过滤
+     *  - true 表示查询已删除（isActive == false）
+     *  - false 表示查询未删除（isActive == true）
+     */
+    private Boolean deleted;
+}


### PR DESCRIPTION
…新增管理员科室管理、管理员疾病管理前端，解决了前端部分弹出小框乱码问题，做了部分管理员排班管理的前端，新增和修改仍需要做修改（由花花接替），美化了管理员首页添加各个管理板块的跳转，美化了登录页面，发现病人挂号需要新增查看挂号信息的部分，也要允许病人取消挂号